### PR TITLE
feat: add support for custom StorageManager, STAC metadata and improve slicing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "deklare"
 version = "0.1.2"
 description = "A data processing framework for data exploration"
 authors = [
-    { name = "Matthias Meyer", email = "contact@niowniow.net" }
+    { name = "Matthias Meyer", email = "contact@niowniow.net" },
+    { name = "Jan Hochstrasser", email = "jhochstrasse@ethz.ch" }
 ]
 dependencies = [
     "dask>=2024.5.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
     "compress-pickle>=2.1.0",
     "cachetools>=5.3.3",
     "numpy>=2",
+    "pystac>=1.11.0",
+    "shapely>=2.0.6",
 ]
 readme = "README.md"
 requires-python = ">= 3.12"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -34,6 +34,7 @@ numpy==2.1.3
     # via deklare
     # via numcodecs
     # via pandas
+    # via shapely
     # via zarr
 packaging==24.1
     # via dask
@@ -41,12 +42,17 @@ pandas==2.2.3
     # via deklare
 partd==1.4.2
     # via dask
+pystac==1.11.0
+    # via deklare
 python-dateutil==2.9.0.post0
     # via pandas
+    # via pystac
 pytz==2024.2
     # via pandas
 pyyaml==6.0.2
     # via dask
+shapely==2.0.6
+    # via deklare
 six==1.16.0
     # via python-dateutil
 toolz==0.12.1

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -4,7 +4,7 @@
 # last locked with the following flags:
 #   pre: false
 #   features: []
-#   all-features: false
+#   all-features: true
 #   with-sources: false
 #   generate-hashes: false
 #   universal: false

--- a/requirements.lock
+++ b/requirements.lock
@@ -4,7 +4,7 @@
 # last locked with the following flags:
 #   pre: false
 #   features: []
-#   all-features: false
+#   all-features: true
 #   with-sources: false
 #   generate-hashes: false
 #   universal: false

--- a/requirements.lock
+++ b/requirements.lock
@@ -34,6 +34,7 @@ numpy==2.1.3
     # via deklare
     # via numcodecs
     # via pandas
+    # via shapely
     # via zarr
 packaging==24.1
     # via dask
@@ -41,12 +42,17 @@ pandas==2.2.3
     # via deklare
 partd==1.4.2
     # via dask
+pystac==1.11.0
+    # via deklare
 python-dateutil==2.9.0.post0
     # via pandas
+    # via pystac
 pytz==2024.2
     # via pandas
 pyyaml==6.0.2
     # via dask
+shapely==2.0.6
+    # via deklare
 six==1.16.0
     # via python-dateutil
 toolz==1.0.0

--- a/src/deklare/__init__.py
+++ b/src/deklare/__init__.py
@@ -18,7 +18,7 @@ import inspect
 
 from .core import it, task
 from .graph import Node, compute
-from .persist import ChunkPersister, HashPersister
+from .persist import ChunkPersister, Persister
 
 
 def deklare_flow(flow):

--- a/src/deklare/persist.py
+++ b/src/deklare/persist.py
@@ -766,9 +766,9 @@ class ChunkPersister:
             'providers': None,
         }
 
-        allowed_kwargs = ['id', 'title', 'keywords', 'license', 'providers']
+        blocked_kwargs = ['extent', 'catalog_type', 'links']
         for k in collection_metadata:
-            if k in allowed_kwargs:
+            if k not in blocked_kwargs:
                 kwargs[k] = collection_metadata[k]
 
         if isinstance(kwargs['providers'], list):

--- a/src/deklare/persist.py
+++ b/src/deklare/persist.py
@@ -416,7 +416,7 @@ def merge_xarray(data, request):
 
 
 @task()
-class ChunkPersister(Persister):
+class ChunkPersister:
     def __init__(
         self,
         store,

--- a/src/deklare/persist.py
+++ b/src/deklare/persist.py
@@ -223,7 +223,7 @@ class Persister():
             str: hash of the requenst
         """
         r = {k: v for k, v in request.items() if k != "self"}
-        s = json.dumps(r, sort_keys=True, skipkeys=True, default=self._string_timestamp)
+        s = json.dumps(r, sort_keys=True, skipkeys=True, default=Persister._string_timestamp)
         request_hash = tokenize(s)
 
         return request_hash

--- a/src/deklare/persist.py
+++ b/src/deklare/persist.py
@@ -74,7 +74,7 @@ class PickleStorageManager(StorageManager):
 
     def write(self, data: T) -> io.BytesIO:
         buffer = io.BytesIO()
-        dump(object, buffer, compression=self.compression)
+        dump(data, buffer, compression=self.compression)
         return buffer
 
     def read(self, buffer: io.BytesIO) -> T:
@@ -429,7 +429,7 @@ class ChunkPersister:
         reference: dict = None,
         force_update=False,
         merge_function=None,
-        storage_manager: StorageManager=PickleStorageManager,
+        storage_manager: StorageManager=PickleStorageManager(),
     ):
         """Chunks every incoming dekriptor into subchunks if deskriptor is larger than segment_slice
          or extends the deskriptor to the respective chunksize if deskriptor is smaller than segment_slice

--- a/src/deklare/persist.py
+++ b/src/deklare/persist.py
@@ -517,7 +517,7 @@ def get_segments(
             iterator = pd.date_range(segment_start, segment_end, freq=_segment_stride)
             segment_end = pd.to_datetime(segment_end)
         else:
-            iterator = range(segment_start, segment_end, _segment_stride)
+            iterator = range(int(segment_start), int(segment_end), _segment_stride)
 
         slices = []
         for start in iterator:
@@ -758,13 +758,14 @@ class ChunkPersister:
             raise RuntimeError(f"Failed to load data. Reason: {failed}")
 
         # update extents
-        collection = pystac.Collection.from_file('/stac/collection.json', self.stac_io) # pretend path is absolute so pystac doesnt try and change it
-        collection.update_extent_from_items()
-        collection.save(
-            catalog_type=pystac.CatalogType.SELF_CONTAINED,
-            dest_href='/stac', # pretend path is absolute so pystac doesnt try and change it
-            stac_io=self.stac_io,
-        )
+        with self.mutex:
+            collection = pystac.Collection.from_file('/stac/collection.json', self.stac_io) # pretend path is absolute so pystac doesnt try and change it
+            collection.update_extent_from_items()
+            collection.save(
+                catalog_type=pystac.CatalogType.SELF_CONTAINED,
+                dest_href='/stac', # pretend path is absolute so pystac doesnt try and change it
+                stac_io=self.stac_io,
+            )
 
         section = self.merge(success, request)
         return section


### PR DESCRIPTION
Added
- Custom `StorageManager`
  - User can create class based on `StorageManager` and pass to `ChunkPersister` during initialization to allow for custom storage format
- STAC metadata
  - View chunks as STAC Item with automatic metadata
  - View dataset as STAC Collection with automatic metadata
  - Have support for additional metadata for Items and Collection
- Improved slicing
  - Re-introduce support for custom stride
  - Correct sign of stride if necessary
  - View value given in `segment_slice` as absolute value  