### PR TITLE
Move STAC Item metadata generation to StacIO

### DIFF
--- a/src/deklare/persist.py
+++ b/src/deklare/persist.py
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License."""
 
 import io
-import os
 import json
 import warnings
 from copy import copy, deepcopy
@@ -23,7 +22,6 @@ from threading import Lock
 from typing import Callable, TypeVar, Generic
 from abc import ABC, abstractmethod
 
-import math
 import pandas as pd
 from cachetools import LRUCache
 from compress_pickle import dump, load
@@ -61,6 +59,8 @@ class StacIO(pystac.StacIO):
             str: The text contained in the file at the location specified by the uri.
         """
         str_src = str(source)
+        if str_src.startswith('/') and len(str_src) > 1:
+            str_src = str_src[1:]
         return self.store[str_src].decode()
 
     def write_text(self, dest: pystac.utils.HREF, txt: str, *args, **kwargs) -> None:
@@ -71,6 +71,9 @@ class StacIO(pystac.StacIO):
             txt : The text to write.
         """
         str_dest = str(dest)
+        if str_dest.startswith('/') and len(str_dest) > 1:
+            str_dest = str_dest[1:]
+
         self.store[str_dest] = txt.encode()
 
     def gen_stac_item_kwargs(self, deskriptor: dict, item_metadata: dict) -> dict:

--- a/src/deklare/persist.py
+++ b/src/deklare/persist.py
@@ -468,12 +468,12 @@ class Persister:
         # save in collection and avoid concurrency issues
         with self._global_lock:
             collection = pystac.Collection.from_file(
-                "stac/collection.json", self.stac_io
+                "/stac/collection.json", self.stac_io
             )  # pretending location is absolute to stop stac from changing path
             collection.add_item(item)
             collection.save(
                 catalog_type=pystac.CatalogType.SELF_CONTAINED,
-                dest_href="stac",  # pretend path is absolute so pystac doesnt try and change it
+                dest_href="/stac",  # pretend path is absolute so pystac doesnt try and change it
                 stac_io=self.stac_io,
             )
 
@@ -600,7 +600,7 @@ class ChunkPersister:
             # create collection if doesn't exist
             try:
                 collection = pystac.Collection.from_file(
-                    "stac/collection.json", self.stac_io
+                    "/stac/collection.json", self.stac_io
                 )
             except:
                 collection_metadata = ChunkPersister._process_collection_metadata(
@@ -612,7 +612,7 @@ class ChunkPersister:
                     collection.add_link(l)
 
                 collection.normalize_and_save(
-                    root_href="stac",  # pretend path is absolute so pystac doesnt try and change it
+                    root_href="/stac",  # pretend path is absolute so pystac doesnt try and change it
                     catalog_type=pystac.CatalogType.SELF_CONTAINED,
                     stac_io=self.stac_io,
                 )
@@ -716,12 +716,12 @@ class ChunkPersister:
             # update extents
             with self.mutex:
                 collection = pystac.Collection.from_file(
-                    "stac/collection.json", self.stac_io
+                    "/stac/collection.json", self.stac_io
                 )  # pretend path is absolute so pystac doesnt try and change it
                 collection.update_extent_from_items()
                 collection.save(
                     catalog_type=pystac.CatalogType.SELF_CONTAINED,
-                    dest_href="stac",  # pretend path is absolute so pystac doesnt try and change it
+                    dest_href="/stac",  # pretend path is absolute so pystac doesnt try and change it
                     stac_io=self.stac_io,
                 )
 


### PR DESCRIPTION
Move STAC Item metadata generation to StacIO to generalize in case deskriptors change for use case. Then the according functions of the StacIO class can be overwritten more easily.
Additionally, the xarray dataset must be merged along the time axis before slicing, or else it may cause an error when selecting parts of it using the slices